### PR TITLE
feat: add task search and filter functionality

### DIFF
--- a/apps/web/src/components/BoardFilters.tsx
+++ b/apps/web/src/components/BoardFilters.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { Search, X, Filter } from 'lucide-react';
+
+export interface FilterState {
+  search: string;
+  priority: string;
+  label: string;
+}
+
+interface BoardFiltersProps {
+  filters: FilterState;
+  onFiltersChange: (filters: FilterState) => void;
+  labels: string[];
+  totalTasks: number;
+  matchingTasks: number;
+}
+
+export default function BoardFilters({
+  filters,
+  onFiltersChange,
+  labels,
+  totalTasks,
+  matchingTasks,
+}: BoardFiltersProps) {
+  const hasActiveFilters = filters.search || filters.priority || filters.label;
+
+  const clearFilters = () => {
+    onFiltersChange({ search: '', priority: '', label: '' });
+  };
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <input
+          type="text"
+          value={filters.search}
+          onChange={(e) =>
+            onFiltersChange({ ...filters, search: e.target.value })
+          }
+          placeholder="Search tasks..."
+          className="rounded-lg border border-gray-300 bg-white pl-9 pr-3 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-56"
+        />
+      </div>
+
+      {/* Priority filter */}
+      <div className="flex items-center gap-1.5">
+        <Filter className="h-4 w-4 text-gray-400" />
+        <select
+          value={filters.priority}
+          onChange={(e) =>
+            onFiltersChange({ ...filters, priority: e.target.value })
+          }
+          className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+        >
+          <option value="">All Priorities</option>
+          <option value="LOW">Low</option>
+          <option value="MEDIUM">Medium</option>
+          <option value="HIGH">High</option>
+          <option value="URGENT">Urgent</option>
+        </select>
+      </div>
+
+      {/* Label filter */}
+      {labels.length > 0 && (
+        <select
+          value={filters.label}
+          onChange={(e) =>
+            onFiltersChange({ ...filters, label: e.target.value })
+          }
+          className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+        >
+          <option value="">All Labels</option>
+          {labels.map((label) => (
+            <option key={label} value={label}>
+              {label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {/* Task count & clear */}
+      {hasActiveFilters && (
+        <>
+          <span className="text-xs text-gray-500">
+            {matchingTasks} of {totalTasks} tasks
+          </span>
+          <button
+            onClick={clearFilters}
+            className="inline-flex items-center gap-1 rounded-lg bg-gray-100 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200 transition-colors"
+          >
+            <X className="h-3 w-3" />
+            Clear filters
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import {
   DndContext,
   DragEndEvent,
@@ -18,6 +18,7 @@ import { useRouter } from 'next/navigation';
 import { Board, Column, Task, getBoard, createColumn, moveTask } from '@/lib/api';
 import KanbanColumn from './KanbanColumn';
 import TaskCard from './TaskCard';
+import BoardFilters, { FilterState } from './BoardFilters';
 
 interface KanbanBoardProps {
   boardId: string;
@@ -30,6 +31,7 @@ export default function KanbanBoard({ boardId }: KanbanBoardProps) {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [isAddingColumn, setIsAddingColumn] = useState(false);
   const [newColumnTitle, setNewColumnTitle] = useState('');
+  const [filters, setFilters] = useState<FilterState>({ search: '', priority: '', label: '' });
   const router = useRouter();
 
   const sensors = useSensors(
@@ -57,6 +59,53 @@ export default function KanbanBoard({ boardId }: KanbanBoardProps) {
   useEffect(() => {
     fetchBoard();
   }, [fetchBoard]);
+
+  // Collect all unique labels across all tasks
+  const allLabels = useMemo(() => {
+    const labelSet = new Set<string>();
+    columns.forEach(col =>
+      col.tasks?.forEach(task => {
+        if (task.label) labelSet.add(task.label);
+      })
+    );
+    return Array.from(labelSet).sort();
+  }, [columns]);
+
+  // Count total and matching tasks
+  const totalTasks = useMemo(
+    () => columns.reduce((sum, col) => sum + (col.tasks?.length || 0), 0),
+    [columns]
+  );
+
+  const taskMatchesFilter = useCallback(
+    (task: Task): boolean => {
+      if (filters.search) {
+        const query = filters.search.toLowerCase();
+        const matchesTitle = task.title.toLowerCase().includes(query);
+        const matchesDesc = task.description?.toLowerCase().includes(query) ?? false;
+        if (!matchesTitle && !matchesDesc) return false;
+      }
+      if (filters.priority && task.priority !== filters.priority) return false;
+      if (filters.label && task.label !== filters.label) return false;
+      return true;
+    },
+    [filters]
+  );
+
+  // Build filtered columns — tasks that don't match are hidden
+  const filteredColumns = useMemo(() => {
+    const hasActiveFilter = filters.search || filters.priority || filters.label;
+    if (!hasActiveFilter) return columns;
+    return columns.map(col => ({
+      ...col,
+      tasks: col.tasks?.filter(taskMatchesFilter) || [],
+    }));
+  }, [columns, filters, taskMatchesFilter]);
+
+  const matchingTasks = useMemo(
+    () => filteredColumns.reduce((sum, col) => sum + (col.tasks?.length || 0), 0),
+    [filteredColumns]
+  );
 
   const handleAddColumn = async () => {
     if (!newColumnTitle.trim()) return;
@@ -214,19 +263,28 @@ export default function KanbanBoard({ boardId }: KanbanBoardProps) {
 
   return (
     <div className="flex flex-col h-[calc(100vh-64px)]">
-      <div className="flex items-center gap-4 px-6 py-4 border-b border-gray-200 bg-white">
-        <button
-          onClick={() => router.push('/')}
-          className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <div>
-          <h1 className="text-xl font-bold text-gray-900">{board.title}</h1>
-          {board.description && (
-            <p className="text-sm text-gray-500">{board.description}</p>
-          )}
+      <div className="flex items-center justify-between gap-4 px-6 py-4 border-b border-gray-200 bg-white">
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => router.push('/')}
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <div>
+            <h1 className="text-xl font-bold text-gray-900">{board.title}</h1>
+            {board.description && (
+              <p className="text-sm text-gray-500">{board.description}</p>
+            )}
+          </div>
         </div>
+        <BoardFilters
+          filters={filters}
+          onFiltersChange={setFilters}
+          labels={allLabels}
+          totalTasks={totalTasks}
+          matchingTasks={matchingTasks}
+        />
       </div>
 
       <div className="flex-1 overflow-x-auto overflow-y-hidden p-6">
@@ -238,7 +296,7 @@ export default function KanbanBoard({ boardId }: KanbanBoardProps) {
             onDragOver={handleDragOver}
             onDragEnd={handleDragEnd}
           >
-            {columns.map(column => (
+            {filteredColumns.map(column => (
               <KanbanColumn
                 key={column.id}
                 column={column}


### PR DESCRIPTION
## Summary
- Adds a search bar to filter tasks by title/description in real-time
- Adds priority dropdown filter (Low, Medium, High, Urgent)
- Adds label dropdown filter (dynamically populated from existing task labels)
- Shows matching task count vs total when filters are active
- Clear filters button to reset all filters

Closes #1

## Type
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] DevOps
- [ ] Documentation

## Area
- [x] Frontend (`apps/web`)
- [ ] Backend (`apps/api`)
- [ ] Shared (`packages/shared`)
- [ ] CI/CD

## Testing
- Build passes (`next build` succeeds with no errors)
- New `BoardFilters` component created with search, priority, and label filters
- `KanbanBoard` updated to use `useMemo` for efficient client-side filtering
- Filtered columns passed to render — tasks hidden when they don't match

## Checklist
- [x] Code compiles without errors
- [x] Tests pass
- [x] Lint passes
- [ ] Swagger docs updated (if API changes)
- [ ] CLAUDE.md updated (if architecture changes)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)