### PR TITLE
fix: CORS error blocking Cloud Run frontend requests

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -6,8 +6,19 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  const allowedOrigins = [
+    'http://localhost:3000',
+    ...(process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : []),
+  ];
+
   app.enableCors({
-    origin: ['http://localhost:3000'],
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin) || origin.endsWith('.run.app')) {
+        callback(null, true);
+      } else {
+        callback(new Error('Not allowed by CORS'));
+      }
+    },
     methods: ['GET', 'POST', 'PATCH', 'DELETE'],
     credentials: true,
   });


### PR DESCRIPTION
## Summary
- API CORS was hardcoded to `localhost:3000` only, blocking all requests from deployed Cloud Run frontend
- Now allows all `*.run.app` origins automatically (covers both dev and prod Cloud Run services)
- Supports additional origins via `CORS_ORIGINS` env var (comma-separated)
- Keeps `localhost:3000` for local development

Closes #5

## Type
- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] DevOps
- [ ] Documentation

## Area
- [ ] Frontend (`apps/web`)
- [x] Backend (`apps/api`)
- [ ] Shared (`packages/shared`)
- [ ] CI/CD

## Testing
- Verify that `https://taskpilot-web-dev-k2ah5vchcq-el.a.run.app` can create boards after deploy
- Verify `localhost:3000` still works for local dev

## Checklist
- [x] Code compiles without errors
- [x] Tests pass
- [x] Lint passes
- [ ] Swagger docs updated (if API changes)
- [ ] CLAUDE.md updated (if architecture changes)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)