### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,8 +1,15 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #f9fafb;
   --foreground: #111827;
+}
+
+.dark {
+  --background: #030712;
+  --foreground: #f9fafb;
 }
 
 @theme inline {
@@ -33,8 +40,16 @@ body {
   border-radius: 3px;
 }
 
+.dark ::-webkit-scrollbar-thumb {
+  background: #4b5563;
+}
+
 ::-webkit-scrollbar-thumb:hover {
   background: #9ca3af;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: #6b7280;
 }
 
 /* Smooth drag transitions */

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
 import "./globals.css";
+import ThemeProvider from "@/components/ThemeProvider";
+import ThemeToggle from "@/components/ThemeToggle";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,40 +29,46 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col bg-gray-50">
-        <header className="h-16 bg-gray-900 border-b border-gray-800 flex items-center px-6 shrink-0">
-          <Link href="/" className="flex items-center gap-3 group">
-            <div className="h-8 w-8 rounded-lg bg-indigo-600 flex items-center justify-center shadow-lg shadow-indigo-600/30">
-              <svg
-                className="h-4.5 w-4.5 text-white"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <rect x="3" y="3" width="7" height="9" rx="1" />
-                <rect x="14" y="3" width="7" height="5" rx="1" />
-                <rect x="14" y="12" width="7" height="9" rx="1" />
-                <rect x="3" y="16" width="7" height="5" rx="1" />
-              </svg>
-            </div>
-            <span className="text-lg font-bold text-white group-hover:text-indigo-300 transition-colors">
-              TaskPilot
-            </span>
-          </Link>
-          <nav className="ml-8 flex items-center gap-1">
-            <Link
-              href="/"
-              className="px-3 py-1.5 rounded-md text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 transition-colors"
-            >
-              Boards
+      <body className="min-h-full flex flex-col bg-gray-50 dark:bg-gray-950">
+        <ThemeProvider>
+          <header className="h-16 bg-gray-900 border-b border-gray-800 flex items-center px-6 shrink-0">
+            <Link href="/" className="flex items-center gap-3 group">
+              <div className="h-8 w-8 rounded-lg bg-indigo-600 flex items-center justify-center shadow-lg shadow-indigo-600/30">
+                <svg
+                  className="h-4.5 w-4.5 text-white"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="3" y="3" width="7" height="9" rx="1" />
+                  <rect x="14" y="3" width="7" height="5" rx="1" />
+                  <rect x="14" y="12" width="7" height="9" rx="1" />
+                  <rect x="3" y="16" width="7" height="5" rx="1" />
+                </svg>
+              </div>
+              <span className="text-lg font-bold text-white group-hover:text-indigo-300 transition-colors">
+                TaskPilot
+              </span>
             </Link>
-          </nav>
-        </header>
-        <main className="flex-1 flex flex-col">{children}</main>
+            <nav className="ml-8 flex items-center gap-1">
+              <Link
+                href="/"
+                className="px-3 py-1.5 rounded-md text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 transition-colors"
+              >
+                Boards
+              </Link>
+            </nav>
+            <div className="ml-auto">
+              <ThemeToggle />
+            </div>
+          </header>
+          <main className="flex-1 flex flex-col">{children}</main>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/src/components/BoardFilters.tsx
+++ b/apps/web/src/components/BoardFilters.tsx
@@ -41,7 +41,7 @@ export default function BoardFilters({
             onFiltersChange({ ...filters, search: e.target.value })
           }
           placeholder="Search tasks..."
-          className="rounded-lg border border-gray-300 bg-white pl-9 pr-3 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-56"
+          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 pl-9 pr-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-56"
         />
       </div>
 
@@ -53,7 +53,7 @@ export default function BoardFilters({
           onChange={(e) =>
             onFiltersChange({ ...filters, priority: e.target.value })
           }
-          className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
         >
           <option value="">All Priorities</option>
           <option value="LOW">Low</option>
@@ -70,7 +70,7 @@ export default function BoardFilters({
           onChange={(e) =>
             onFiltersChange({ ...filters, label: e.target.value })
           }
-          className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
         >
           <option value="">All Labels</option>
           {labels.map((label) => (
@@ -84,12 +84,12 @@ export default function BoardFilters({
       {/* Task count & clear */}
       {hasActiveFilters && (
         <>
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
             {matchingTasks} of {totalTasks} tasks
           </span>
           <button
             onClick={clearFilters}
-            className="inline-flex items-center gap-1 rounded-lg bg-gray-100 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200 transition-colors"
+            className="inline-flex items-center gap-1 rounded-lg bg-gray-100 dark:bg-gray-800 px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
           >
             <X className="h-3 w-3" />
             Clear filters

--- a/apps/web/src/components/BoardList.tsx
+++ b/apps/web/src/components/BoardList.tsx
@@ -51,8 +51,8 @@ export default function BoardList() {
     <div className="p-8 max-w-7xl mx-auto">
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Your Boards</h1>
-          <p className="mt-1 text-gray-500">Manage your projects and tasks</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Your Boards</h1>
+          <p className="mt-1 text-gray-500 dark:text-gray-400">Manage your projects and tasks</p>
         </div>
         <button
           onClick={() => setShowCreateModal(true)}
@@ -64,10 +64,10 @@ export default function BoardList() {
       </div>
 
       {boards.length === 0 ? (
-        <div className="text-center py-16 bg-white rounded-xl border border-dashed border-gray-300">
-          <Layout className="mx-auto h-12 w-12 text-gray-400" />
-          <h3 className="mt-4 text-lg font-semibold text-gray-900">No boards yet</h3>
-          <p className="mt-2 text-gray-500">Create your first board to get started.</p>
+        <div className="text-center py-16 bg-white dark:bg-gray-900 rounded-xl border border-dashed border-gray-300 dark:border-gray-700">
+          <Layout className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
+          <h3 className="mt-4 text-lg font-semibold text-gray-900 dark:text-gray-100">No boards yet</h3>
+          <p className="mt-2 text-gray-500 dark:text-gray-400">Create your first board to get started.</p>
           <button
             onClick={() => setShowCreateModal(true)}
             className="mt-6 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 transition-colors"
@@ -82,32 +82,32 @@ export default function BoardList() {
             <div
               key={board.id}
               onClick={() => router.push(`/board/${board.id}`)}
-              className="group relative bg-white rounded-xl border border-gray-200 p-5 cursor-pointer hover:shadow-lg hover:border-indigo-300 transition-all duration-200"
+              className="group relative bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 p-5 cursor-pointer hover:shadow-lg hover:border-indigo-300 dark:hover:border-indigo-600 transition-all duration-200"
             >
               <div className="flex items-start justify-between">
-                <div className="h-10 w-10 rounded-lg bg-indigo-100 flex items-center justify-center">
-                  <Layout className="h-5 w-5 text-indigo-600" />
+                <div className="h-10 w-10 rounded-lg bg-indigo-100 dark:bg-indigo-900/50 flex items-center justify-center">
+                  <Layout className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
                 </div>
                 <button
                   onClick={(e) => handleDelete(e, board.id)}
-                  className="opacity-0 group-hover:opacity-100 p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 transition-all"
+                  className="opacity-0 group-hover:opacity-100 p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950 transition-all"
                 >
                   <Trash2 className="h-4 w-4" />
                 </button>
               </div>
-              <h3 className="mt-4 font-semibold text-gray-900 text-lg">{board.title}</h3>
+              <h3 className="mt-4 font-semibold text-gray-900 dark:text-gray-100 text-lg">{board.title}</h3>
               {board.description && (
-                <p className="mt-1 text-sm text-gray-500 line-clamp-2">{board.description}</p>
+                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 line-clamp-2">{board.description}</p>
               )}
-              <div className="mt-4 flex items-center gap-1.5 text-xs text-gray-400">
+              <div className="mt-4 flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-500">
                 <Calendar className="h-3.5 w-3.5" />
                 <span>{format(new Date(board.createdAt), 'MMM d, yyyy')}</span>
               </div>
               <div className="mt-3 flex items-center gap-2">
-                <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                <span className="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-800 px-2.5 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-400">
                   {board.columns?.length || 0} columns
                 </span>
-                <span className="inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-600">
+                <span className="inline-flex items-center rounded-full bg-indigo-50 dark:bg-indigo-900/40 px-2.5 py-0.5 text-xs font-medium text-indigo-600 dark:text-indigo-400">
                   {board.columns?.reduce((acc, col) => acc + (col.tasks?.length || 0), 0) || 0} tasks
                 </span>
               </div>

--- a/apps/web/src/components/CreateBoardModal.tsx
+++ b/apps/web/src/components/CreateBoardModal.tsx
@@ -32,12 +32,12 @@ export default function CreateBoardModal({ onClose, onCreated }: CreateBoardModa
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
+      <div className="relative bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
         <div className="flex items-center justify-between mb-5">
-          <h2 className="text-xl font-bold text-gray-900">Create New Board</h2>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Create New Board</h2>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
           >
             <X className="h-5 w-5" />
           </button>
@@ -45,7 +45,7 @@ export default function CreateBoardModal({ onClose, onCreated }: CreateBoardModa
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="board-title" className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label htmlFor="board-title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
               Board Title
             </label>
             <input
@@ -54,14 +54,14 @@ export default function CreateBoardModal({ onClose, onCreated }: CreateBoardModa
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder="e.g., Product Roadmap"
-              className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3.5 py-2.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
               autoFocus
             />
           </div>
 
           <div>
-            <label htmlFor="board-desc" className="block text-sm font-medium text-gray-700 mb-1.5">
-              Description <span className="text-gray-400">(optional)</span>
+            <label htmlFor="board-desc" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+              Description <span className="text-gray-400 dark:text-gray-500">(optional)</span>
             </label>
             <textarea
               id="board-desc"
@@ -69,7 +69,7 @@ export default function CreateBoardModal({ onClose, onCreated }: CreateBoardModa
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What is this board for?"
               rows={3}
-              className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow resize-none"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3.5 py-2.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow resize-none"
             />
           </div>
 
@@ -77,7 +77,7 @@ export default function CreateBoardModal({ onClose, onCreated }: CreateBoardModa
             <button
               type="button"
               onClick={onClose}
-              className="rounded-lg px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors"
+              className="rounded-lg px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
             >
               Cancel
             </button>

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -249,7 +249,7 @@ export default function KanbanBoard({ boardId }: KanbanBoardProps) {
     return (
       <div className="flex items-center justify-center h-[calc(100vh-64px)]">
         <div className="text-center">
-          <h2 className="text-xl font-semibold text-gray-900">Board not found</h2>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Board not found</h2>
           <button
             onClick={() => router.push('/')}
             className="mt-4 text-indigo-600 hover:text-indigo-500 font-medium"
@@ -263,18 +263,18 @@ export default function KanbanBoard({ boardId }: KanbanBoardProps) {
 
   return (
     <div className="flex flex-col h-[calc(100vh-64px)]">
-      <div className="flex items-center justify-between gap-4 px-6 py-4 border-b border-gray-200 bg-white">
+      <div className="flex items-center justify-between gap-4 px-6 py-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
         <div className="flex items-center gap-4">
           <button
             onClick={() => router.push('/')}
-            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
           >
             <ArrowLeft className="h-5 w-5" />
           </button>
           <div>
-            <h1 className="text-xl font-bold text-gray-900">{board.title}</h1>
+            <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{board.title}</h1>
             {board.description && (
-              <p className="text-sm text-gray-500">{board.description}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">{board.description}</p>
             )}
           </div>
         </div>
@@ -316,13 +316,13 @@ export default function KanbanBoard({ boardId }: KanbanBoardProps) {
           {/* Add Column */}
           <div className="w-72 shrink-0">
             {isAddingColumn ? (
-              <div className="bg-gray-100 rounded-xl p-3 space-y-2">
+              <div className="bg-gray-100 dark:bg-gray-800 rounded-xl p-3 space-y-2">
                 <input
                   type="text"
                   value={newColumnTitle}
                   onChange={(e) => setNewColumnTitle(e.target.value)}
                   placeholder="Column title..."
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                  className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
                   autoFocus
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') handleAddColumn();
@@ -345,7 +345,7 @@ export default function KanbanBoard({ boardId }: KanbanBoardProps) {
                       setIsAddingColumn(false);
                       setNewColumnTitle('');
                     }}
-                    className="rounded-lg px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-200 transition-colors"
+                    className="rounded-lg px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
                   >
                     Cancel
                   </button>
@@ -354,7 +354,7 @@ export default function KanbanBoard({ boardId }: KanbanBoardProps) {
             ) : (
               <button
                 onClick={() => setIsAddingColumn(true)}
-                className="w-full flex items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 p-4 text-sm font-medium text-gray-500 hover:border-indigo-400 hover:text-indigo-600 hover:bg-indigo-50/50 transition-colors"
+                className="w-full flex items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-600 p-4 text-sm font-medium text-gray-500 dark:text-gray-400 hover:border-indigo-400 hover:text-indigo-600 hover:bg-indigo-50/50 dark:hover:bg-indigo-950/30 transition-colors"
               >
                 <Plus className="h-4 w-4" />
                 Add Column

--- a/apps/web/src/components/KanbanColumn.tsx
+++ b/apps/web/src/components/KanbanColumn.tsx
@@ -73,18 +73,18 @@ export default function KanbanColumn({ column, onRefresh }: KanbanColumnProps) {
                   setIsEditingTitle(false);
                 }
               }}
-              className="text-sm font-semibold text-gray-700 bg-white border border-indigo-300 rounded px-2 py-0.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="text-sm font-semibold text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-indigo-300 rounded px-2 py-0.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
               autoFocus
             />
           ) : (
             <h3
-              className="text-sm font-semibold text-gray-700 uppercase tracking-wide cursor-pointer hover:text-indigo-600 transition-colors"
+              className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide cursor-pointer hover:text-indigo-600 transition-colors"
               onDoubleClick={() => setIsEditingTitle(true)}
             >
               {column.title}
             </h3>
           )}
-          <span className="inline-flex items-center justify-center h-5 min-w-[20px] rounded-full bg-gray-200 px-1.5 text-xs font-medium text-gray-600">
+          <span className="inline-flex items-center justify-center h-5 min-w-[20px] rounded-full bg-gray-200 dark:bg-gray-700 px-1.5 text-xs font-medium text-gray-600 dark:text-gray-400">
             {tasks.length}
           </span>
         </div>
@@ -92,20 +92,20 @@ export default function KanbanColumn({ column, onRefresh }: KanbanColumnProps) {
         <div className="relative">
           <button
             onClick={() => setShowMenu(!showMenu)}
-            className="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+            className="p-1 rounded text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
           >
             <MoreHorizontal className="h-4 w-4" />
           </button>
           {showMenu && (
             <>
               <div className="fixed inset-0 z-10" onClick={() => setShowMenu(false)} />
-              <div className="absolute right-0 z-20 mt-1 w-40 bg-white rounded-lg shadow-lg border border-gray-200 py-1">
+              <div className="absolute right-0 z-20 mt-1 w-40 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1">
                 <button
                   onClick={() => {
                     setIsEditingTitle(true);
                     setShowMenu(false);
                   }}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
                 >
                   <Edit3 className="h-3.5 w-3.5" />
                   Rename
@@ -115,7 +115,7 @@ export default function KanbanColumn({ column, onRefresh }: KanbanColumnProps) {
                     handleDeleteColumn();
                     setShowMenu(false);
                   }}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                   Delete
@@ -130,8 +130,8 @@ export default function KanbanColumn({ column, onRefresh }: KanbanColumnProps) {
         ref={setNodeRef}
         className={`flex-1 rounded-xl p-2 space-y-2 min-h-[120px] transition-colors duration-200 ${
           isOver
-            ? 'bg-indigo-50 ring-2 ring-indigo-300 ring-inset'
-            : 'bg-gray-100/80'
+            ? 'bg-indigo-50 dark:bg-indigo-950/30 ring-2 ring-indigo-300 dark:ring-indigo-700 ring-inset'
+            : 'bg-gray-100/80 dark:bg-gray-800/50'
         }`}
       >
         <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
@@ -146,7 +146,7 @@ export default function KanbanColumn({ column, onRefresh }: KanbanColumnProps) {
 
         <button
           onClick={() => setShowTaskModal(true)}
-          className="w-full flex items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-gray-300 py-2 text-sm text-gray-500 hover:border-indigo-400 hover:text-indigo-600 hover:bg-white transition-colors"
+          className="w-full flex items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600 py-2 text-sm text-gray-500 dark:text-gray-400 hover:border-indigo-400 hover:text-indigo-600 hover:bg-white dark:hover:bg-gray-800 transition-colors"
         >
           <Plus className="h-4 w-4" />
           Add Task

--- a/apps/web/src/components/TaskCard.tsx
+++ b/apps/web/src/components/TaskCard.tsx
@@ -45,7 +45,7 @@ export default function TaskCard({ task, onClick }: TaskCardProps) {
     <div
       ref={setNodeRef}
       style={style}
-      className={`group bg-white rounded-lg border border-gray-200 p-3 cursor-pointer hover:shadow-md hover:border-indigo-200 transition-all duration-150 ${
+      className={`group bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 p-3 cursor-pointer hover:shadow-md hover:border-indigo-200 dark:hover:border-indigo-700 transition-all duration-150 ${
         isDragging ? 'opacity-50 shadow-lg rotate-2 scale-105' : ''
       }`}
       onClick={onClick}
@@ -60,9 +60,9 @@ export default function TaskCard({ task, onClick }: TaskCardProps) {
           <GripVertical className="h-4 w-4" />
         </button>
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-gray-900 leading-snug">{task.title}</p>
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 leading-snug">{task.title}</p>
           {task.description && (
-            <p className="mt-1 text-xs text-gray-500 line-clamp-2">{task.description}</p>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 line-clamp-2">{task.description}</p>
           )}
           <div className="mt-2 flex items-center flex-wrap gap-1.5">
             <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${priority.color}`}>

--- a/apps/web/src/components/TaskModal.tsx
+++ b/apps/web/src/components/TaskModal.tsx
@@ -70,14 +70,14 @@ export default function TaskModal({ task, columnId, order, onClose, onSaved }: T
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-white rounded-2xl shadow-xl w-full max-w-lg mx-4 p-6">
+      <div className="relative bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-lg mx-4 p-6">
         <div className="flex items-center justify-between mb-5">
-          <h2 className="text-xl font-bold text-gray-900">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
             {isEdit ? 'Edit Task' : 'New Task'}
           </h2>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
           >
             <X className="h-5 w-5" />
           </button>
@@ -85,7 +85,7 @@ export default function TaskModal({ task, columnId, order, onClose, onSaved }: T
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="task-title" className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label htmlFor="task-title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
               Title
             </label>
             <input
@@ -94,13 +94,13 @@ export default function TaskModal({ task, columnId, order, onClose, onSaved }: T
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder="What needs to be done?"
-              className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3.5 py-2.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
               autoFocus
             />
           </div>
 
           <div>
-            <label htmlFor="task-desc" className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label htmlFor="task-desc" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
               Description
             </label>
             <textarea
@@ -109,13 +109,13 @@ export default function TaskModal({ task, columnId, order, onClose, onSaved }: T
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Add more details..."
               rows={3}
-              className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow resize-none"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3.5 py-2.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow resize-none"
             />
           </div>
 
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                 Priority
               </label>
               <select
@@ -132,7 +132,7 @@ export default function TaskModal({ task, columnId, order, onClose, onSaved }: T
             </div>
 
             <div>
-              <label htmlFor="task-label" className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label htmlFor="task-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                 Label
               </label>
               <input
@@ -141,13 +141,13 @@ export default function TaskModal({ task, columnId, order, onClose, onSaved }: T
                 value={label}
                 onChange={(e) => setLabel(e.target.value)}
                 placeholder="e.g., frontend"
-                className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
+                className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3.5 py-2.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
               />
             </div>
           </div>
 
           <div>
-            <label htmlFor="task-due" className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label htmlFor="task-due" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
               Due Date
             </label>
             <input
@@ -177,7 +177,7 @@ export default function TaskModal({ task, columnId, order, onClose, onSaved }: T
               <button
                 type="button"
                 onClick={onClose}
-                className="rounded-lg px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors"
+                className="rounded-lg px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
               >
                 Cancel
               </button>

--- a/apps/web/src/components/ThemeProvider.tsx
+++ b/apps/web/src/components/ThemeProvider.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('taskpilot-theme') as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('taskpilot-theme', theme);
+  }, [theme, mounted]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  if (!mounted) {
+    return <>{children}</>;
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from './ThemeProvider';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-gray-800 transition-colors"
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      {theme === 'light' ? (
+        <Moon className="h-4.5 w-4.5" />
+      ) : (
+        <Sun className="h-4.5 w-4.5" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Dark/light mode toggle button (Moon/Sun icon) in the header
- Persists preference in localStorage (`taskpilot-theme`)
- Detects system preference (`prefers-color-scheme`) as default
- All components styled for both themes using Tailwind `dark:` variant

Closes #9

## Type
- [x] Feature

## Area
- [x] Frontend (`apps/web`)

## Testing
- Toggle works and persists across page refreshes
- System preference detected on first visit
- All pages (board list, board view, modals, filters) styled for dark mode
- Build passes with no errors

## Checklist
- [x] Code compiles without errors
- [x] All components have dark mode styles
- [x] localStorage persistence working
- [x] System preference detection working

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)